### PR TITLE
fix for dhcp procedure

### DIFF
--- a/src/eth.c
+++ b/src/eth.c
@@ -386,6 +386,7 @@ void wait_100ms(void)
 void
 eth_init()
 {
+   unsigned char timer = 40;
    eth_drop();
 
    /*
@@ -425,6 +426,9 @@ eth_init()
    wait_100ms();
    POKE(0xd6e1,3);
    POKE(0xd6e1,0);
+   // wait four seconds to allow PHY to come up again
+   while (timer--)
+     wait_100ms();
    
    // XXX Enable ethernet IRQs?
 }

--- a/src/haustierbegriff.c
+++ b/src/haustierbegriff.c
@@ -140,6 +140,7 @@ void main(void)
 	 mac_local.b[3],mac_local.b[4],mac_local.b[5]);
   
   // Setup WeeIP
+  printf("Resetting ethernet controller\n");
   weeip_init();
   task_cancel(eth_task);
   task_add(eth_task, 0, 0,"eth");
@@ -184,6 +185,7 @@ void main(void)
 	break;
       } else POKE(0xD610,0);
     }
+    task_periodic();
   }
   POKE(198,0);
   printf("Preparing to connect to %s\n",bbs_list[nbbs].name);


### PR DESCRIPTION
The dhcp client implementation was not providing the server identifier in the dhcprequest message, which lead to servers not sending an ACK (FritzBox seems to not send an ACK in that case, others even send a NAK).
This is fixed in this commit.

Other changes:
- Wait 4 seconds after eth controller reset to allow the PHY to come up again
- Continue to call task_periodic while waiting for a key press in the main menu, so ARP requests are still getting responded
